### PR TITLE
Fix cpuinfo & jmetal package names

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
 
 optional-dependencies.benchmarks = [
   "botorch",
-  "py-cpuinfo",
   "desdeo",
   "fast-pareto",
   "jmetalpy",
@@ -54,6 +53,7 @@ optional-dependencies.benchmarks = [
   "optuna",
   "pandas>=2",
   "paretoset",
+  "py-cpuinfo",
   "pymoo",
   "seqme",
 ]


### PR DESCRIPTION
Currently, cloning moocore and running `uv sync` in the `python` directory fails due to this.

Looking on pypi, these are the appropriate packages:
- `cpuinfo` from [py-cpuinfo](https://pypi.org/project/py-cpuinfo/)
- `jmetal` from [jmetalpy](https://pypi.org/project/jmetalpy/)

`uv sync` succeeds after this change.