### PR TITLE
Add spack recipe for py-moocore

### DIFF
--- a/spack/packages/py-moocore/package.py
+++ b/spack/packages/py-moocore/package.py
@@ -1,0 +1,24 @@
+# ruff: noqa: F403, F405
+from spack.package import *
+
+
+class PyMoocore(PythonPackage):
+    """Core Algorithms for Multi-Objective Optimization."""
+
+    homepage = "https://multi-objective.github.io/moocore/python/"
+    pypi = "moocore/moocore-0.2.0.tar.gz"
+
+    version(
+        "0.2.0",
+        sha256="3dc601f85f9a4743ed50ddd027dca30e3bb55c899916a092c2ece495b1b2de08",
+    )
+
+    depends_on("c", type="build")
+    depends_on("gmake@4.4:", type="build")
+
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-setuptools@77.0.3:", type="build")
+    depends_on("py-wheel", type="build")
+    depends_on("py-cffi@1.16:", type=("build", "run"))
+    depends_on("py-numpy@1.24:", type=("build", "run"))
+    depends_on("py-platformdirs", type=("build", "run"))

--- a/spack/repo.yaml
+++ b/spack/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: 'moocore'


### PR DESCRIPTION
Python recipe for the pkg, to be added in https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages once checked. To try the compilation with spack:
git clone https://github.com/spack/spack.git
. ./spack/share/spack/setup-env.sh
spack compiler find
spack env create moocore-env
spacktivate moocore-env
spack repo add moocore/spack
spack add py-moocore
spack concretize -f
spack install

Closes #63.
