### PR TITLE
Python-side dimension-limit checks, large-dimension tests, and 1-column igd support (#72)

### DIFF
--- a/c/igd.h
+++ b/c/igd.h
@@ -65,7 +65,7 @@ gd_common_helper_(const enum objs_agree_t agree,
                   const double * restrict points_r, size_t size_r,
                   bool plus, bool psize, uint_fast8_t p)
 {
-    ASSUME(2 <= dim);
+    ASSUME(1 <= dim);
     if (size_a == 0) return INFINITY;
     ASSUME(size_a > 0);
     ASSUME(size_r > 0);

--- a/python/src/moocore/_moocore.py
+++ b/python/src/moocore/_moocore.py
@@ -174,11 +174,33 @@ def _all_positive(x: ArrayLike) -> bool:
     return x.min() > 0
 
 
+# Maximum number of objectives (columns) supported by the C library. These
+# mirror the limits defined in c/config.h: most functions support up to 255
+# (the range of dimension_t == uint_fast8_t), while the hypervolume and
+# hypervolume-approximation functions use a smaller limit for efficiency.
+# Inputs exceeding these would overflow fixed-size buffers or the dimension_t
+# type, so they are rejected in Python before reaching C.
+DIMENSION_MAX = 255
+HV_DIMENSION_MAX = 31
+HVAPPROX_DIMENSION_MAX = 31
+
+
+def _check_nobj(nobj: int, name: str, dim_max: int = DIMENSION_MAX) -> None:
+    """Raise ValueError if the number of objectives exceeds the C limit."""
+    if nobj > dim_max:
+        raise ValueError(
+            f"{name}() supports at most {dim_max} objectives (columns), "
+            f"but the input has {nobj}"
+        )
+
+
 def _unary_refset_common(
     points: ArrayLike,
     ref: ArrayLike,
     maximise: bool | Sequence[bool],
     check_all_positive: bool = False,
+    name: str = "function",
+    min_dim: int = 1,
 ):
     # Convert to numpy.array in case the user provides a list.  We use
     # np.asarray(dtype=float) to convert it to floating-point, otherwise if a
@@ -187,6 +209,12 @@ def _unary_refset_common(
     points = np.asarray(points, dtype=float)
     ref = np.atleast_2d(np.asarray(ref, dtype=float))
     nobj = points.shape[1]
+    _check_nobj(nobj, name)
+    if nobj < min_dim:
+        raise ValueError(
+            f"{name}() requires at least {min_dim} objectives (columns), "
+            f"but the input has {nobj}"
+        )
     if nobj != ref.shape[1]:
         raise ValueError(
             f"points and ref need to have the same number of columns ({nobj} != {ref.shape[1]})"
@@ -237,7 +265,7 @@ def igd(
 
     """
     points_p, n, d, ref_p, ref_size, maximise_p = _unary_refset_common(
-        points, ref, maximise
+        points, ref, maximise, name="igd"
     )
     return lib.IGD(points_p, n, d, ref_p, ref_size, maximise_p)
 
@@ -303,7 +331,7 @@ def igd_plus(
 
     """  # noqa: D401
     points_p, n, d, ref_p, ref_size, maximise_p = _unary_refset_common(
-        points, ref, maximise
+        points, ref, maximise, name="igd_plus"
     )
     return lib.IGD_plus(points_p, n, d, ref_p, ref_size, maximise_p)
 
@@ -343,7 +371,7 @@ def avg_hausdorff_dist(
         raise ValueError("'p' must be larger than zero")
 
     points_p, n, d, ref_p, ref_size, maximise_p = _unary_refset_common(
-        points, ref, maximise
+        points, ref, maximise, name="avg_hausdorff_dist"
     )
     p = ffi.cast("unsigned int", p)
     return lib.avg_Hausdorff_dist(
@@ -396,7 +424,7 @@ def epsilon_additive(
 
     """
     points_p, n, d, ref_p, ref_size, maximise_p = _unary_refset_common(
-        points, ref, maximise
+        points, ref, maximise, name="epsilon_additive", min_dim=2
     )
     return lib.epsilon_additive(points_p, n, d, ref_p, ref_size, maximise_p)
 
@@ -432,7 +460,7 @@ def epsilon_mult(
 
     """
     points_p, n, d, ref_p, ref_size, maximise_p = _unary_refset_common(
-        points, ref, maximise, check_all_positive=True
+        points, ref, maximise, check_all_positive=True, name="epsilon_mult", min_dim=2
     )
     return lib.epsilon_mult(points_p, n, d, ref_p, ref_size, maximise_p)
 
@@ -563,6 +591,7 @@ def hypervolume(
     nobj = points.shape[1]
     if nobj == 0:
         raise ValueError("input points must have at least 1 column")
+    _check_nobj(nobj, "hypervolume", HV_DIMENSION_MAX)
     # Make sure it is a 1D array of length nobj.
     ref = array_1d_of_length_n(np.asarray(ref, dtype=float), nobj, name="ref")
 
@@ -658,6 +687,7 @@ class Hypervolume:
             raise ValueError(
                 f"points and ref need to have the same number of objectives ({points.shape[1]} != {nobj})"
             )
+        _check_nobj(nobj, "hypervolume", HV_DIMENSION_MAX)
 
         # FIXME: Do this in C.
         if maximise.any():
@@ -847,6 +877,7 @@ def hv_contributions(
     # an int array.
     points, points_copied = asarray_maybe_copy(points)
     nobj = points.shape[1]
+    _check_nobj(nobj, "hv_contributions", HV_DIMENSION_MAX)
     ref = array_1d_of_length_n(np.asarray(ref, dtype=float), nobj, name="ref")
     maximise = _parse_maximise(maximise, nobj)
     # FIXME: Do this in C.
@@ -1019,6 +1050,7 @@ def hv_approx(
     # an int array.
     points = np.asarray(points, dtype=float)
     nobj = points.shape[1]
+    _check_nobj(nobj, "hv_approx", HVAPPROX_DIMENSION_MAX)
     ref = array_1d_of_length_n(np.asarray(ref, dtype=float), nobj, name="ref")
 
     if not is_integer_value(nsamples):
@@ -1333,6 +1365,7 @@ def is_nondominated(
             nondom[points.argmax() if maximise else points.argmin()] = True
             return nondom
 
+    _check_nobj(nobj, "is_nondominated")
     keep_weakly = ffi.cast("bool", bool(keep_weakly))
     maximise_p = _parse_maximise_to_bool_array(maximise, nobj)
     points_p, npoints, nobj = np2d_to_double_array(
@@ -1408,6 +1441,7 @@ def any_dominated(
         # If there are more than one row, then something is dominated.
         return True
 
+    _check_nobj(nobj, "any_dominated")
     maximise_p = _parse_maximise_to_bool_array(maximise, nobj)
     points_p, npoints, nobj = np2d_to_double_array(
         points, ctype_shape=("size_t", "uint_fast8_t")
@@ -1725,6 +1759,7 @@ def pareto_rank(
         if nobj == 0:
             return np.zeros(shape=nrows, dtype=int)
 
+    _check_nobj(nobj, "pareto_rank")
     if maximise.any():
         # FIXME: Do this in C.
         if not points_copied:

--- a/python/src/moocore/_moocore.py
+++ b/python/src/moocore/_moocore.py
@@ -460,7 +460,12 @@ def epsilon_mult(
 
     """
     points_p, n, d, ref_p, ref_size, maximise_p = _unary_refset_common(
-        points, ref, maximise, check_all_positive=True, name="epsilon_mult", min_dim=2
+        points,
+        ref,
+        maximise,
+        check_all_positive=True,
+        name="epsilon_mult",
+        min_dim=2,
     )
     return lib.epsilon_mult(points_p, n, d, ref_p, ref_size, maximise_p)
 

--- a/python/tests/test_dim1_metrics.py
+++ b/python/tests/test_dim1_metrics.py
@@ -1,0 +1,30 @@
+# ruff: noqa: D100, D103
+# These tests require the relaxed `ASSUME(1 <= dim)` in c/igd.h (optional
+# patch): single-column IGD-family metrics are mathematically well-defined and
+# are called with 1 column by released downstream code (pymoo 0.6.2 uses
+# moocore.igd on design-space data of single-variable problems).
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import moocore
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3])
+def test_igd_family_single_column(seed):
+    rng = np.random.default_rng(seed)
+    a = rng.random((6, 1))
+    r = rng.random((4, 1))
+
+    igd_ref = np.mean([np.min(np.abs(a - x)) for x in r.ravel()])
+    igdp_ref = np.mean([np.min(np.maximum(a - x, 0)) for x in r.ravel()])
+    gd_ref = np.mean([np.min(np.abs(r - x)) for x in a.ravel()])
+
+    assert_allclose(moocore.igd(a, ref=r), igd_ref)
+    assert_allclose(moocore.igd_plus(a, ref=r), igdp_ref)
+    assert_allclose(moocore.avg_hausdorff_dist(a, ref=r), max(igd_ref, gd_ref))
+
+
+def test_igd_single_column_identical_is_zero():
+    x = np.arange(5.0).reshape(-1, 1)
+    assert moocore.igd(x, ref=x) == 0.0

--- a/python/tests/test_dimension_limits.py
+++ b/python/tests/test_dimension_limits.py
@@ -1,0 +1,176 @@
+# ruff: noqa: D100, D103
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import moocore
+
+
+# --- reference implementations (independent, pure numpy) --------------------
+
+
+def igd_bruteforce(data, ref):
+    # mean over ref points of the min Euclidean distance to data
+    d = np.sqrt(((ref[:, None, :] - data[None, :, :]) ** 2).sum(axis=2))
+    return float(d.min(axis=1).mean())
+
+
+def igd_plus_bruteforce(data, ref):
+    # like IGD but distances only count where data is worse than ref (minimise)
+    diff = np.maximum(data[None, :, :] - ref[:, None, :], 0.0)
+    d = np.sqrt((diff**2).sum(axis=2))
+    return float(d.min(axis=1).mean())
+
+
+def epsilon_additive_bruteforce(data, ref):
+    # min factor eps s.t. some data point + eps dominates each ref point
+    return float(
+        max(min(max(a - r) for a in data) for r in ref)
+    )
+
+
+def ranks_from_fronts_reference(F):
+    # naive O(N^2 M) non-dominated ranking, correct at any dimension
+    n = F.shape[0]
+    ranks = np.full(n, -1)
+    remaining = set(range(n))
+    r = 0
+    while remaining:
+        idx = list(remaining)
+        front = []
+        for i in idx:
+            dominated = False
+            for j in idx:
+                if j == i:
+                    continue
+                if np.all(F[j] <= F[i]) and np.any(F[j] < F[i]):
+                    dominated = True
+                    break
+            if not dominated:
+                front.append(i)
+        for i in front:
+            ranks[i] = r
+            remaining.discard(i)
+        r += 1
+    return ranks
+
+
+# --- large-dimension correctness (beyond 31, up to the 255 limit) ----------
+
+DIMS = [32, 64, 128, 255]
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_igd_large_dim_matches_reference(dim):
+    rng = np.random.default_rng(dim)
+    data = rng.random((6, dim))
+    ref = rng.random((8, dim))
+    assert_allclose(moocore.igd(data, ref=ref), igd_bruteforce(data, ref))
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_igd_plus_large_dim_matches_reference(dim):
+    rng = np.random.default_rng(dim + 1)
+    data = rng.random((6, dim))
+    ref = rng.random((8, dim))
+    assert_allclose(
+        moocore.igd_plus(data, ref=ref), igd_plus_bruteforce(data, ref)
+    )
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_epsilon_additive_large_dim_matches_reference(dim):
+    rng = np.random.default_rng(dim + 2)
+    data = rng.random((6, dim))
+    ref = rng.random((8, dim))
+    assert_allclose(
+        moocore.epsilon_additive(data, ref=ref),
+        epsilon_additive_bruteforce(data, ref),
+    )
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_igd_identical_sets_is_zero_large_dim(dim):
+    # analytic case: IGD of a set against itself is exactly 0
+    rng = np.random.default_rng(dim + 3)
+    x = rng.random((5, dim))
+    assert moocore.igd(x, ref=x) == 0.0
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_pareto_rank_large_dim_chain(dim):
+    # dominance chain: row i dominates row j for i < j -> ranks 0,1,2,...
+    F = (np.arange(10)[:, None] * np.ones((1, dim))).astype(float)
+    assert_allclose(moocore.pareto_rank(F), np.arange(10))
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_pareto_rank_large_dim_matches_reference(dim):
+    # real structure in the first 3 columns, remaining columns constant
+    rng = np.random.default_rng(dim + 4)
+    base = rng.random((40, 3))
+    F = np.hstack([base, np.zeros((40, dim - 3))])
+    assert_allclose(
+        moocore.pareto_rank(F), ranks_from_fronts_reference(F)
+    )
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_is_nondominated_large_dim_matches_reference(dim):
+    rng = np.random.default_rng(dim + 5)
+    base = rng.random((40, 3))
+    F = np.hstack([base, np.zeros((40, dim - 3))])
+    expected = ranks_from_fronts_reference(F) == 0
+    assert_allclose(moocore.is_nondominated(F), expected)
+
+
+# --- errors are raised at the documented limits -----------------------------
+
+GENERAL_255 = [
+    ("igd", lambda x: moocore.igd(x, ref=x)),
+    ("igd_plus", lambda x: moocore.igd_plus(x, ref=x)),
+    ("avg_hausdorff_dist", lambda x: moocore.avg_hausdorff_dist(x, ref=x)),
+    ("epsilon_additive", lambda x: moocore.epsilon_additive(x, ref=x)),
+    ("epsilon_mult", lambda x: moocore.epsilon_mult(x, ref=x)),
+    ("pareto_rank", lambda x: moocore.pareto_rank(x)),
+    ("is_nondominated", lambda x: moocore.is_nondominated(x)),
+    ("any_dominated", lambda x: moocore.any_dominated(x)),
+]
+
+HV_31 = [
+    ("hypervolume", lambda x: moocore.hypervolume(x, ref=np.ones(x.shape[1]))),
+    (
+        "hv_contributions",
+        lambda x: moocore.hv_contributions(x, ref=np.ones(x.shape[1])),
+    ),
+    ("hv_approx", lambda x: moocore.hv_approx(x, ref=np.ones(x.shape[1]))),
+]
+
+
+@pytest.mark.parametrize("name,fn", GENERAL_255)
+def test_general_functions_raise_above_255(name, fn):
+    rng = np.random.default_rng(0)
+    # at the limit: must not raise
+    fn(rng.random((4, 255)))
+    # above the limit: must raise ValueError (not crash)
+    with pytest.raises(ValueError, match="at most 255"):
+        fn(rng.random((4, 256)))
+
+
+@pytest.mark.parametrize("name,fn", HV_31)
+def test_hv_functions_raise_above_31(name, fn):
+    rng = np.random.default_rng(0)
+    # at the limit: must not raise
+    fn(rng.random((4, 31)))
+    # above the limit: must raise ValueError (not crash / silently wrong)
+    with pytest.raises(ValueError, match="at most 31"):
+        fn(rng.random((4, 32)))
+
+
+def test_epsilon_raises_on_single_column():
+    # the C epsilon kernel is unrolled for the first two dimensions, so a
+    # 1-column input used to read out of bounds and return garbage
+    x = np.ones((3, 1))
+    for fn in (moocore.epsilon_additive, moocore.epsilon_mult):
+        with pytest.raises(ValueError, match="at least 2"):
+            fn(x, ref=x)

--- a/python/tests/test_dimension_limits.py
+++ b/python/tests/test_dimension_limits.py
@@ -24,9 +24,7 @@ def igd_plus_bruteforce(data, ref):
 
 def epsilon_additive_bruteforce(data, ref):
     # min factor eps s.t. some data point + eps dominates each ref point
-    return float(
-        max(min(max(a - r) for a in data) for r in ref)
-    )
+    return float(max(min(max(a - r) for a in data) for r in ref))
 
 
 def ranks_from_fronts_reference(F):
@@ -110,9 +108,7 @@ def test_pareto_rank_large_dim_matches_reference(dim):
     rng = np.random.default_rng(dim + 4)
     base = rng.random((40, 3))
     F = np.hstack([base, np.zeros((40, dim - 3))])
-    assert_allclose(
-        moocore.pareto_rank(F), ranks_from_fronts_reference(F)
-    )
+    assert_allclose(moocore.pareto_rank(F), ranks_from_fronts_reference(F))
 
 
 @pytest.mark.parametrize("dim", DIMS)


### PR DESCRIPTION
Closes the remaining checklist items from #72.

## Commit 1 — Python-side dimension-limit checks + tests

Adds a `_check_nobj()` helper and per-function `ValueError`s so that inputs beyond what the C library supports are rejected in Python instead of reaching C as undefined behavior:

| Functions | Limit | Before this PR |
|---|---|---|
| `igd`, `igd_plus`, `avg_hausdorff_dist`, `epsilon_additive`, `epsilon_mult`, `pareto_rank`, `is_nondominated`, `any_dominated` | 255 (range of `dimension_t`) | 256 columns **segfaulted** (`dimension_t` wraparound) |
| `hypervolume` (function + class), `hv_contributions`, `hv_approx` | 31 | 32 columns **silently returned a wrong value** (release build) |
| `epsilon_additive`, `epsilon_mult` | at least 2 | 1 column **read out of bounds and returned garbage** (see below) |

New `test_dimension_limits.py`:
- large-dimension correctness at 32/64/128/255 columns for `igd`, `igd_plus`, `epsilon_additive`, `pareto_rank`, `is_nondominated` — verified against independent pure-numpy references (~0.3 s total),
- error-raising tests at each limit (at-limit succeeds, limit+1 raises).

**Note on epsilon:** while testing the lower bound we found that `epsilon_helper_` is unrolled over the first two dimensions (`MAX(eps_value_agree_(0), eps_value_agree_(1))` unconditionally), so a 1-column input performs an out-of-bounds read and returns garbage — e.g. `epsilon_additive` returned `0.616` where the correct value is `0.009` (formula cross-checked against moocore at 2–3 columns). Reachable from Python in all released versions; now rejected with a clear error.

## Commit 2 — relax `igd.h` to `ASSUME(1 <= dim)` (drop if you disagree)

The `gd_common_helper_` loop is fully general in `dim`, so the `2 <= dim` lower bound is purely conservative there: with `1 <= dim`, `igd`/`igd_plus`/`avg_hausdorff_dist` compute exact results for 1-column input (tests included in `test_dim1_metrics.py`) and higher dimensions are unchanged.

Why legalize rather than reject: **pymoo 0.6.2 (current release) calls `moocore.igd` on design-space data**, so any single-variable problem passes a 1-column array in production. Today that violates the `ASSUME` (it happens to work on GCC release builds but would assert under `DEBUG=1`). A `ValueError` here would retroactively break those installs; relaxing the assume makes the existing behavior well-defined. `epsilon.h` is deliberately untouched — its `2 <= dim` is load-bearing (see above).

This is a separate commit so it's easy to drop if you'd rather handle the lower bound differently.

## Verification

- New tests: 44 (`test_dimension_limits.py` 40, `test_dim1_metrics.py` 4)
- Full suite on this branch: **115 passed, 2 xfailed** (Linux/GCC, Python 3.11)

## Open questions (not in this PR)

- Would you prefer the limit constants exposed from C (via cffi) instead of mirrored in `_moocore.py`? Happy to change.
- NaN/inf checking (your earlier point): confirmed `igd` with NaN silently returns `0.0` today. A SciPy-style opt-out `check_finite=True` kwarg would avoid always paying the extra pass — can do as a follow-up if you want it.
- Numpy fallback above 255: skipped for now per your comment; can contribute later if demand appears.

Downstream context: anyoptimization/pymoo#793.
